### PR TITLE
Chunk Ratio Limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.o
 *.gc*
-.vscode/
+.vscode/*
+!.vscode/launch.json
+!.vscode/tasks.json
 *.a
 .obsidian/
 my_village

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "C Launch",
+      "cwd": "${workspaceFolder}",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/build/debug/my_village",
+      "stopAtEntry": false,
+      "launchCompleteCommand": "exec-run",
+      "linux": {
+        "MIMode": "gdb",
+        "miDebuggerPath": "/usr/bin/gdb"
+      },
+      "preLaunchTask": "Debug Build"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,10 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Debug Build",
+            "command": "make",
+            "args": ["debug"]
+        },
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ ASANARGS				=	-fsanitize=address -g3
 
 TESTARGS				=	-DTEST -fprofile-arcs -ftest-coverage --coverage -lcriterion
 
+DEBUGARGS				=	-g3
+
 BUILD_DIR				=	./build/
 
 SRC_DIR					=	./src/
@@ -60,6 +62,8 @@ VAL_DIR					=	$(BUILD_DIR)valgrind/
 ASAN_DIR				=	$(BUILD_DIR)asan/
 
 TEST_DIR				=	$(BUILD_DIR)tests/
+
+DEBUG_DIR				=	$(BUILD_DIR)debug/
 
 LIB_DIR					=	./lib/
 
@@ -79,6 +83,8 @@ ASANOBJ					=	$(addprefix $(ASAN_DIR), $(SRC:.c=.o))
 
 TESTOBJ					=	$(addprefix $(TEST_DIR), $(SRC:.c=.o))	\
 							$(addprefix $(TEST_DIR), $(TSRC:.c=.o))
+
+DEBUGOBJ				=	$(addprefix $(DEBUG_DIR), $(SRC:.c=.o))
 
 # Targets
 
@@ -108,6 +114,10 @@ $(TEST_DIR): 		| $(BUILD_DIR)
 	rsync -a -f"+ */" -f"- *" $(SRC_ROOT) $(TEST_DIR)
 	rsync -a -f"+ */" -f"- *" $(TSRC_ROOT) $(TEST_DIR)
 
+$(DEBUG_DIR): 		| $(BUILD_DIR)
+	mkdir -p $(DEBUG_DIR)
+	rsync -a -f"+ */" -f"- *" $(SRC_ROOT) $(DEBUG_DIR)
+
 $(PROD_DIR)%.o:		$(SRC_ROOT)%.c | $(PROD_DIR)
 	$(CC) -c $< -o $@ $(CFLAGS) $(LDFLAGS)
 
@@ -120,8 +130,8 @@ $(ASAN_DIR)%.o:		$(SRC_ROOT)%.c | $(ASAN_DIR)
 $(TEST_DIR)%.o:		$(SRC_ROOT)%.c | $(TEST_DIR)
 	$(CC) -c $< -o $@ $(CFLAGS) $(LDFLAGS) $(TESTARGS)
 
-$(TEST_DIR)%.o:		$(TSRC_ROOT)%.c | $(TEST_DIR)
-	$(CC) -c $< -o $@ $(CFLAGS) $(LDFLAGS) $(TESTARGS)
+$(DEBUG_DIR)%.o:		$(SRC_ROOT)%.c | $(DEBUG_DIR)
+	$(CC) -c $< -o $@ $(CFLAGS) $(LDFLAGS) $(DEBUGARGS)
 
 $(VAL_DIR)$(NAME):	$(VALOBJ) | $(VAL_DIR)
 	$(CC) -o $(VAL_DIR)$(NAME) $(VALOBJ) $(CFLAGS) $(LDFLAGS) $(VALARGS)
@@ -132,6 +142,9 @@ $(ASAN_DIR)$(NAME):	$(ASANOBJ) | $(ASAN_DIR)
 $(TEST_DIR)$(NAME):	$(TESTOBJ) | $(TEST_DIR)
 	$(CC) -o $(TEST_DIR)$(NAME) $(TESTOBJ) $(CFLAGS) $(LDFLAGS) $(TESTARGS)
 
+$(DEBUG_DIR)$(NAME):	$(DEBUGOBJ) | $(DEBUG_DIR)
+	$(CC) -o $(DEBUG_DIR)$(NAME) $(DEBUGOBJ) $(CFLAGS) $(LDFLAGS) $(DEBUGARGS)
+
 lib:
 	for lib in $(LIBS); do make -C $(LIB_DIR)$$lib; done
 
@@ -140,6 +153,8 @@ grind:				$(VAL_DIR)$(NAME)
 sanitize:			$(ASAN_DIR)$(NAME)
 
 unit_tests:			$(TEST_DIR)$(NAME)
+
+debug:				$(DEBUG_DIR)$(NAME)
 
 clean:
 	rm -f $(TESTOBJ:.o=.gcda) $(TESTOBJ:.o=.gcno) $(TESTOBJ:.o=.gcov)

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -12,8 +12,8 @@ bool chunk_bounds_size(const chunk_bounds_t *bounds, v2_t *pos_buf)
         return false;
     pos_buf->x = bounds->to_x - bounds->from_x;
     pos_buf->y = bounds->to_y - bounds->from_y;
-    if (pos_buf->x == 0 && pos_buf->y == 0)
-        return true;
+    // if (pos_buf->x == 0 && pos_buf->y == 0)
+    //     return true;
     pos_buf->x++;
     pos_buf->y++;
     return true;
@@ -133,15 +133,6 @@ Test(chunk, init)
         cr_assert_null(VEC_FAST_AT(tile_t, &chunk.tiles, i).prop);
         cr_assert_null(VEC_FAST_AT(tile_t, &chunk.tiles, i).biome);
     }
-}
-
-Test(chunk, bad_init)
-{
-    chunk_t chunk = {0};
-
-    cr_assert_not(chunk_init(&chunk, &(chunk_bounds_t){0, 0, 0, 0}));
-    cr_assert_not(chunk_init(&chunk, &(chunk_bounds_t){10, 10, 10, 10}));
-    cr_assert_not(chunk_init(&chunk, &(chunk_bounds_t){-1, -1, -1, -1}));
 }
 
 Test(chunk, get_tile_absolute)

--- a/src/main.c
+++ b/src/main.c
@@ -58,8 +58,14 @@ int MAIN(void)
     world_t world = {0};
     renderer_t renderer = {0};
 
-    world_init(&world, 100, 10);
-    renderer_init(&renderer, &(display_settings_t){800, 600, 32});
+    if (!world_init(&world, 3, 2)) {
+        dprintf(2, "ERROR: Failed to initialize world\n");
+    }
+    renderer_init(&renderer, &(display_settings_t){
+        .screen_width=800,
+        .screen_height=600,
+        .tile_size_px=32
+    });
     setup_debug_map(&renderer, &world);
     render_and_display(&renderer, &world);
     renderer_deinit(&renderer);

--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include "chunk.h"
+#include "registry.h"
 #include "orientation.h"
 #include "prop.h"
 #include "v2.h"
@@ -48,7 +50,6 @@ static void setup_debug_map(renderer_t *r, world_t *world)
                 world_place_prop(world, big_tree_prop, (v2_t){x, y}, ORIENT_LEFT, false);
             else if (rand() % 7 == 0)
                 world_place_prop(world, tree_prop, (v2_t){x, y}, ORIENT_LEFT, false);
-        
         }
     }
 }
@@ -58,8 +59,9 @@ int MAIN(void)
     world_t world = {0};
     renderer_t renderer = {0};
 
-    if (!world_init(&world, 3, 2)) {
+    if (!world_init(&world, 50, 0)) {
         dprintf(2, "ERROR: Failed to initialize world\n");
+        return EXIT_FAILURE;
     }
     renderer_init(&renderer, &(display_settings_t){
         .screen_width=800,
@@ -67,8 +69,9 @@ int MAIN(void)
         .tile_size_px=32
     });
     setup_debug_map(&renderer, &world);
+    reg_map(&world.chunk_reg, (reg_callback_t)chunk_print);
     render_and_display(&renderer, &world);
     renderer_deinit(&renderer);
     world_deinit(&world);
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -69,7 +69,6 @@ int MAIN(void)
         .tile_size_px=32
     });
     setup_debug_map(&renderer, &world);
-    reg_map(&world.chunk_reg, (reg_callback_t)chunk_print);
     render_and_display(&renderer, &world);
     renderer_deinit(&renderer);
     world_deinit(&world);

--- a/src/render/renderer/renderer_debug.c
+++ b/src/render/renderer/renderer_debug.c
@@ -36,12 +36,10 @@ static void draw_grid(renderer_t *renderer, world_t *world)
                 DEBUG_CHUNK_LINE_THICKNESS, DEBUG_CHUNK_LINE_COLOR);
         }
     }
-    if (i % chunk_size_px != 0) {
-        DrawLineEx((Vector2){0, i}, (Vector2){world_size_px, i},
-            DEBUG_CHUNK_LINE_THICKNESS, DEBUG_CHUNK_LINE_COLOR);
-        DrawLineEx((Vector2){i, 0}, (Vector2){i, world_size_px},
-            DEBUG_CHUNK_LINE_THICKNESS, DEBUG_CHUNK_LINE_COLOR);
-    }
+    DrawLineEx((Vector2){0, world_size_px}, (Vector2){world_size_px, world_size_px},
+        DEBUG_CHUNK_LINE_THICKNESS, DEBUG_CHUNK_LINE_COLOR);
+    DrawLineEx((Vector2){world_size_px, 0}, (Vector2){world_size_px, world_size_px},
+        DEBUG_CHUNK_LINE_THICKNESS, DEBUG_CHUNK_LINE_COLOR);
 }
 
 static void draw_top_bar(renderer_t *renderer, world_t *world)

--- a/src/render/renderer/renderer_display.c
+++ b/src/render/renderer/renderer_display.c
@@ -128,6 +128,7 @@ bool render_and_display(renderer_t *renderer, world_t *world)
 
     if (!renderer || !world)
         return false;
+    SetTraceLogLevel(LOG_NONE);
     InitWindow(
         renderer->settings.screen_width,
         renderer->settings.screen_height,

--- a/src/world/world_chunk.c
+++ b/src/world/world_chunk.c
@@ -1,44 +1,63 @@
+#include <stdio.h>
 #include "chunk.h"
 #include "registry.h"
 #include "v2.h"
 #include "world.h"
-#include <stdio.h>
 
-static bool init_chunk_line(world_t *world, size_t size,
-    size_t chunk_size, size_t y, size_t size_rest)
+static bool init_chunk_line(world_t *world, size_t size, size_t chunk_size, size_t y)
 {
     chunk_t *chunk = NULL;
-    size_t max_chunk_size = chunk_size > size ? size : chunk_size;
+    chunk_bounds_t bounds = {0};
 
-    for (size_t x = 0; x < size - size_rest; x += max_chunk_size) {
+    for (size_t x = 0; x < size; x += chunk_size) {
         chunk = reg_new_elem(&world->chunk_reg);
         if (!chunk)
             return false;
-        if (!chunk_init(chunk, &(chunk_bounds_t){
-                x, y, x + max_chunk_size - 1, y + max_chunk_size - 1
-            }))
+        bounds = (chunk_bounds_t){x, y, x + chunk_size - 1, y + chunk_size - 1};
+        if (!chunk_init(chunk, &bounds))
             return false;
     }
-    if (size_rest == 0)
-        return true;
-    chunk = reg_new_elem(&world->chunk_reg);
-    return chunk && chunk_init(chunk, &(chunk_bounds_t){size - size_rest,
-        y, size - 1, y + max_chunk_size - 1});
+    return true;
+}
+
+static size_t compute_chunk_size(size_t size)
+{
+    size_t *csize = NULL;
+    reg_t chunk_sizes = {0};
+
+    if (!reg_init(&chunk_sizes, sizeof(size_t), size / 2))
+        return 0;
+    for (int i = size - 1; i > 0; i--) {
+        if (size % i != 0)
+            continue;
+        csize = reg_new_elem(&chunk_sizes);
+        if (!csize)
+            return 0;
+        *csize = i;
+    }
+    switch (REG_SIZE(chunk_sizes)) {
+        case 0 : return 0;
+        case 1 : return *REG_AT(size_t, &chunk_sizes, 0);
+        default: return *REG_AT(size_t, &chunk_sizes, REG_SIZE(chunk_sizes) / 2 - 1);
+    }
 }
 
 bool world_init_chunks(world_t *world, size_t size, size_t chunk_size)
 {
-    size_t size_rest = size % chunk_size;
-
+    if (chunk_size == 0)
+        chunk_size = compute_chunk_size(size);
+    world->chunk_size = chunk_size;
     if (!world || size == 0 || chunk_size == 0)
         return false;
-    for (size_t y = 0; y < size - size_rest; y += chunk_size) {
-        if (!init_chunk_line(world, size, chunk_size, y, size_rest))
+    if (size % chunk_size != 0) {
+        dprintf(2, "Invalid world size (chunk_size must be a multiple of size)\n");
+        return false;
+    }
+    for (size_t y = 0; y < size; y += chunk_size) {
+        if (!init_chunk_line(world, size, chunk_size, y))
             return false;
     }
-    if (size_rest == 0)
-        return true;
-    return init_chunk_line(world, size, size_rest, size - size_rest, 0);
+    return true;
 }
 
 static bool is_in_bounds(const chunk_bounds_t *b, v2_t pos)
@@ -65,13 +84,13 @@ chunk_t *world_get_chunk(world_t *world, v2_t pos)
 
 #ifdef TEST
 #include <criterion/criterion.h>
+#include <criterion/redirect.h>
 
 Test(world, chunk_bad_init)
 {
     world_t world = {0};
 
     cr_assert_not(world_init(&world, 0, 0));
-    cr_assert_not(world_init(&world, 10, 0));
     cr_assert_not(world_init(&world, 0, 10));
 }
 
@@ -87,29 +106,36 @@ static int count_tiles(world_t *world)
     return tiles;
 }
 
-Test(world, chunk_init_chunk_fragmentation)
+Test(world, chunk_init_chunk_fragmentation, .init=cr_redirect_stderr)
 {
     unsigned int max_size = 20;
     unsigned int max_chunk_sizes = 20;
+    size_t tiles = 0;
     world_t world = {0};
+    bool success = false;
 
     for (unsigned int size = 2; size <= max_size; size++) {
         for (unsigned int chunk_size = 2; chunk_size <= max_chunk_sizes; chunk_size++) {
-            cr_assert(world_init(&world, size, chunk_size),
-                "Failed to init a %dx%d world with %dx%d chunks", size, size, chunk_size, chunk_size);
-            cr_assert_eq(count_tiles(&world), size * size);
+            success = world_init(&world, size, chunk_size);
+            if (size % chunk_size != 0) {
+                cr_assert_not(success);
+                continue;
+            }
+            cr_assert(success, "Failed to init a (size: %d, chunk_size: %d)", size, chunk_size);
+            tiles = count_tiles(&world);
+            cr_assert_eq(tiles, size * size,
+                "Wrong tile count. Expected %d, got %ld (size: %d, chunk_size: %d)",
+                size * size, tiles, size, chunk_size);
             world_deinit(&world);
         }
     }
 }
 
-Test(world, chunk_init_too_big)
+Test(world, chunk_init_too_big, .init=cr_redirect_stderr)
 {
     world_t world = {0};
 
-    cr_assert(world_init(&world, 50, 100));
-    cr_assert_eq(REG_AT(chunk_t, &world.chunk_reg, 0)->bounds.to_x, 49);
-    world_deinit(&world);
+    cr_assert_not(world_init(&world, 50, 100));
 }
 
 Test(world, get_chunk_single_chunk)

--- a/src/world/world_chunk.c
+++ b/src/world/world_chunk.c
@@ -75,12 +75,41 @@ Test(world, chunk_bad_init)
     cr_assert_not(world_init(&world, 0, 10));
 }
 
+static int count_tiles(world_t *world)
+{
+    int tiles = 0;
+    chunk_t *chunk = NULL;
+
+    for (unsigned int i = 0; i < REG_SIZE(world->chunk_reg); i++) {
+        chunk = REG_AT(chunk_t, &world->chunk_reg, i);
+        tiles += chunk->tiles.size;
+    }
+    return tiles;
+}
+
+Test(world, chunk_init_chunk_fragmentation)
+{
+    unsigned int max_size = 20;
+    unsigned int max_chunk_sizes = 20;
+    world_t world = {0};
+
+    for (unsigned int size = 2; size <= max_size; size++) {
+        for (unsigned int chunk_size = 2; chunk_size <= max_chunk_sizes; chunk_size++) {
+            cr_assert(world_init(&world, size, chunk_size),
+                "Failed to init a %dx%d world with %dx%d chunks", size, size, chunk_size, chunk_size);
+            cr_assert_eq(count_tiles(&world), size * size);
+            world_deinit(&world);
+        }
+    }
+}
+
 Test(world, chunk_init_too_big)
 {
     world_t world = {0};
 
     cr_assert(world_init(&world, 50, 100));
     cr_assert_eq(REG_AT(chunk_t, &world.chunk_reg, 0)->bounds.to_x, 49);
+    world_deinit(&world);
 }
 
 Test(world, get_chunk_single_chunk)
@@ -93,6 +122,7 @@ Test(world, get_chunk_single_chunk)
     cr_assert_eq(world_get_chunk(&world, (v2_t){9, 9}),
         REG_AT(chunk_t, &world.chunk_reg, 0));
     cr_assert_eq(world_get_chunk(&world, (v2_t){10, 10}), NULL);
+    world_deinit(&world);
 }
 
 Test(world, get_chunk_multiple_chunks)
@@ -109,6 +139,7 @@ Test(world, get_chunk_multiple_chunks)
     cr_assert_eq(world_get_chunk(&world, (v2_t){9, 9}),
         REG_AT(chunk_t, &world.chunk_reg, 3));
     cr_assert_eq(world_get_chunk(&world, (v2_t){10, 10}), NULL);
+    world_deinit(&world);
 }
 
 Test(world, get_chunk_lots_of_chunks)
@@ -129,6 +160,7 @@ Test(world, get_chunk_lots_of_chunks)
     cr_assert_eq(world_get_chunk(&world, (v2_t){99, 99}),
         REG_AT(chunk_t, &world.chunk_reg, 99));
     cr_assert_eq(world_get_chunk(&world, (v2_t){100, 100}), NULL);
+    world_deinit(&world);
 }
 
 #endif

--- a/src/world/world_factory.c
+++ b/src/world/world_factory.c
@@ -5,10 +5,9 @@
 
 bool world_init(world_t *world, size_t size, size_t chunk_size)
 {
-    if (!world || size == 0 || chunk_size == 0)
+    if (!world || size == 0)
         return false;
     world->size = size;
-    world->chunk_size = chunk_size;
     return WORLD_INIT_REGISTRY(world, asset, ASSET_REGISTRY_BASE_SIZE)
         && WORLD_INIT_REGISTRY(world, prop, PROP_REGISTRY_BASE_SIZE)
         && WORLD_INIT_REGISTRY(world, terrain, TERRAIN_REGISTRY_BASE_SIZE)


### PR DESCRIPTION
Added a chunk ratio limit, preventing users from creating map with a `chunk_size` that is not a multiple of `size`.